### PR TITLE
Arreglo del color del boton En Analisis

### DIFF
--- a/src/components/EstadosComponente.jsx
+++ b/src/components/EstadosComponente.jsx
@@ -47,7 +47,7 @@ const getEstadoProps = (estado) => {
     switch (estado) {
         case 'Recibido':
             return { label: getEstadoDisplay(estado), variant: 'outlined', sx: { ...estilosDeBoton, backgroundColor: colores.Recibido.bg, color: colores.Recibido.text } };
-        case 'EnAnalisis':
+        case 'En Análisis':
             return { label: getEstadoDisplay(estado), color: 'info', variant: 'filled', sx: { ...estilosDeBoton, backgroundColor: colores.EnAnalisis.bg, color: colores.EnAnalisis.text } };
         case 'Observado':
             return { label: getEstadoDisplay(estado), sx: { ...estilosDeBoton, backgroundColor: colores.Observado.bg, color: colores.Observado.text }, variant: 'filled' };


### PR DESCRIPTION
Cuando una solicitud pasaba de 'Recibido' a 'En Analisis' no cambiaba el color del boton, y se debia a un error de tipeo en el front